### PR TITLE
Concurrency | Marasanov

### DIFF
--- a/src/main/java/ru/mail/polis/homework/concurrency/state/CalculateContainer.java
+++ b/src/main/java/ru/mail/polis/homework/concurrency/state/CalculateContainer.java
@@ -1,5 +1,6 @@
 package ru.mail.polis.homework.concurrency.state;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -31,26 +32,38 @@ import java.util.function.UnaryOperator;
  */
 public class CalculateContainer<T> {
 
-    private State state = State.START;
+    private final AtomicReference<T> result;
 
-    private T result;
+    private final AtomicReference<State> state = new AtomicReference<>(State.START);
 
-    public CalculateContainer(T result) {
-        this.result = result;
+    public CalculateContainer(T initResult) {
+        this.result = new AtomicReference<>(initResult);
     }
 
     /**
      * Инициализирует результат и переводит контейнер в состояние INIT (Возможно только из состояния START и FINISH)
      */
     public void init(UnaryOperator<T> initOperator) {
-
+        while (!state.compareAndSet(State.FINISH, State.INIT) && !state.compareAndSet(State.START, State.INIT)) {
+            if (state.get() == State.CLOSE) {
+                System.out.println("Error! Transition CLOSE -> INIT");
+                return;
+            }
+        }
+        result.getAndUpdate(initOperator);
     }
 
     /**
      * Вычисляет результат и переводит контейнер в состояние RUN (Возможно только из состояния INIT)
      */
     public void run(BinaryOperator<T> runOperator, T value) {
-
+        while (!state.compareAndSet(State.INIT, State.RUN)) {
+            if (state.get() == State.CLOSE) {
+                System.out.println("Error! Transition CLOSE -> RUN");
+                return;
+            }
+        }
+        result.accumulateAndGet(value, runOperator);
     }
 
 
@@ -58,7 +71,13 @@ public class CalculateContainer<T> {
      * Передает результат потребителю и переводит контейнер в состояние FINISH (Возможно только из состояния RUN)
      */
     public void finish(Consumer<T> finishConsumer) {
-
+        while (!state.compareAndSet(State.RUN, State.FINISH)) {
+            if (state.get() == State.CLOSE) {
+                System.out.println("Error! Transition CLOSE -> FINISH");
+                return;
+            }
+        }
+        finishConsumer.accept(result.get());
     }
 
 
@@ -67,15 +86,21 @@ public class CalculateContainer<T> {
      * (Возможно только из состояния FINISH)
      */
     public void close(Consumer<T> closeConsumer) {
-
+        while (!state.compareAndSet(State.FINISH, State.CLOSE)) {
+            if (state.get() == State.CLOSE) {
+                System.out.println("Error! Transition CLOSE -> CLOSE");
+                return;
+            }
+        }
+        closeConsumer.accept(result.get());
     }
 
 
     public T getResult() {
-        return result;
+        return result.get();
     }
 
     public State getState() {
-        return state;
+        return state.get();
     }
 }

--- a/src/test/java/ru/mail/polis/homework/concurrency/executor/SimpleExecutorTest.java
+++ b/src/test/java/ru/mail/polis/homework/concurrency/executor/SimpleExecutorTest.java
@@ -1,0 +1,97 @@
+package ru.mail.polis.homework.concurrency.executor;
+
+import org.junit.Assert;
+import org.junit.Test;
+import ru.mail.polis.homework.concurrency.executor.SimpleExecutor;
+import static org.junit.Assert.assertEquals;
+
+
+public class SimpleExecutorTest {
+
+    // исполнение одной задачи с интервалами во времени
+    @Test
+    public void oneTaskTest() throws InterruptedException {
+        SimpleExecutor simpleExecutor = new SimpleExecutor();
+        Runnable task = () -> {
+            System.out.println("task in progress");
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("task is done");
+        };
+
+        // запускаем по очереди 5 задач, давая фору на исполнение в примерно 500 мс
+        for (int i = 0; i < 5; i++) {
+            simpleExecutor.execute(task);
+            Thread.sleep(2500);
+            Assert.assertEquals(1, simpleExecutor.getLiveThreadsCount());
+        }
+
+        simpleExecutor.shutdown();
+    }
+
+    // исполнение одновременно n, где n - максимальное число потоков исполнителя
+    @Test
+    public void lessThanLimitTasksTest() throws InterruptedException {
+        int n = 10;
+        SimpleExecutor simpleExecutor = new SimpleExecutor(10);
+        Runnable task = () -> {
+            System.out.println("task in progress");
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("task is done");
+        };
+
+        for (int j = 0; j < 5; j++) {
+            for (int i = 0; i < n - 1; i++) {
+                simpleExecutor.execute(task);
+            }
+            // запускаем n - 1 задач и проверяем количество воркеров сначала
+            // во время исполнения, затем после конца исполнения
+            Thread.sleep(1250);
+            System.out.println("assertion1");
+            Assert.assertEquals(n - 1, simpleExecutor.getLiveThreadsCount());
+            Thread.sleep(1250);
+            System.out.println("assertion2\n");
+            Assert.assertEquals(n - 1, simpleExecutor.getLiveThreadsCount());
+        }
+
+        simpleExecutor.shutdown();
+    }
+
+    // исполнение одновременно n + m задач, где n - максимальное число потоков исполнителя
+    @Test
+    public void moreThanLimitTasksTest() throws InterruptedException {
+        int n = 10;
+        int m = 5;
+        SimpleExecutor simpleExecutor = new SimpleExecutor(10);
+        Runnable task = () -> {
+            System.out.println("task in progress");
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("task is done");
+        };
+
+        for (int i = 0; i < n + m; i++) {
+            simpleExecutor.execute(task);
+        }
+        Thread.sleep(1500);
+        Assert.assertEquals(n, simpleExecutor.getLiveThreadsCount());
+        System.out.println("assertion1");
+        Thread.sleep(1500);
+        Assert.assertEquals(n, simpleExecutor.getLiveThreadsCount());
+        System.out.println("assertion2");
+        Thread.sleep(1500);
+
+        simpleExecutor.shutdown();
+    }
+
+}

--- a/src/test/java/ru/mail/polis/homework/concurrent/state/CalculateContainerTest.java
+++ b/src/test/java/ru/mail/polis/homework/concurrent/state/CalculateContainerTest.java
@@ -15,7 +15,7 @@ public class CalculateContainerTest {
     @Test
     public void deadlockTest() {
         ExecutorService service = Executors.newFixedThreadPool(10);
-        for (int i = 0; i < 1_000_000; i++) {
+        for (int i = 0; i < 10_000; i++) {
             System.out.println("i = " + i);
             CalculateContainer<Double> container = new CalculateContainer<>(10d);
             for (int j = 0; j < 10; j++) {


### PR DESCRIPTION
Уменьшил число вычислений до 10_000 в CalculateContainerTest и CalculateContainerManager. Тесты по CalculateContainerManager не проходят по непонятным причинам (каждый из тестов сваливается после вызова run()). SimpleExecutor не проходит второй тест, где запускаем n-1 задач с интервалами, не понимаю, где надо вводить ещё синхронизации, чтобы новые потоки не создавались. Причем тест с одной задачей проходит, новые потоки не создаются при повторном выполнении одной задачи 